### PR TITLE
Issue 1/QBRA ILS/LLZ: simple panel to create BRA areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
 # qBRA
+
+QBRA is a collection of QGIS tools for aviation procedures. This
+repository currently includes the `QBRA ILS/LLZ` plugin, which
+creates BRA (Basic Radio Aids) areas around a selected navaid using
+the same calculations as the original QGIS script.
+
+## QBRA ILS/LLZ plugin
+
+### Folder structure
+
+The plugin lives in the `qbra_ils_llz` folder and follows the same
+structure as other QBRA/qpansopy plugins:
+
+- `qbra_ils_llz/qbra_plugin.py` – main plugin entry class.
+- `qbra_ils_llz/modules/ils_llz_logic.py` – all BRA geometry
+  calculations (ported from the legacy script).
+- `qbra_ils_llz/dockwidgets/ils/ils_llz_dockwidget.py` – controller for
+  the dock panel.
+- `qbra_ils_llz/ui/ils/ils_llz_panel.ui` – Qt Designer UI for the
+  panel.
+- `qbra_ils_llz/icons/ils_llz.svg` – plugin icon.
+- `qbra_ils_llz/metadata.txt` – QGIS plugin metadata.
+
+### Installation in QGIS
+
+1. Create a ZIP file that contains the `qbra_ils_llz` folder at the
+   root (for example `qbra_ils_llz.zip`).
+2. In QGIS, open `Plugins` → `Manage and Install Plugins...`.
+3. Choose `Install from ZIP` and select the ZIP you created.
+4. Enable the `QBRA ILS/LLZ` plugin in the Plugins list.
+
+### Usage
+
+1. Load your navaid point layer and routing/runway line layer into the
+   QGIS project.
+2. Make sure the navaid layer has the same attribute order as the
+   original script (site elevation in field 4, runway identifier in
+   field 5).
+3. Select one navaid feature and one routing/runway feature.
+4. Click the `QBRA ILS/LLZ` toolbar button or menu entry to open the
+   dock panel.
+5. Choose the navaid and routing layers in the panel (they default to
+   the active layers), then press `Calculate`.
+6. The plugin will create a new memory layer with the BRA polygons and
+   add it to the project.
+
+The calculations and resulting geometries are intended to match the
+original `ILS_LLZ_single_frequency.py` script.

--- a/qbra_ils_llz/__init__.py
+++ b/qbra_ils_llz/__init__.py
@@ -1,0 +1,4 @@
+from .qbra_plugin import QbraPlugin
+
+def classFactory(iface):
+	return QbraPlugin(iface)

--- a/qbra_ils_llz/dockwidgets/ils/ils_llz_dockwidget.py
+++ b/qbra_ils_llz/dockwidgets/ils/ils_llz_dockwidget.py
@@ -1,0 +1,148 @@
+from qgis.PyQt import uic
+from qgis.PyQt.QtCore import Qt, pyqtSignal
+from qgis.PyQt.QtWidgets import QDockWidget
+from qgis.core import QgsWkbTypes, QgsPoint
+from qgis.utils import iface
+
+import os
+
+UI_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "ui", "ils", "ils_llz_panel.ui")
+
+class IlsLlzDockWidget(QDockWidget):
+    calculateRequested = pyqtSignal()
+    closedRequested = pyqtSignal()
+
+    def __init__(self, iface_):
+        super().__init__("QBRA ILS/LLZ")
+        self.iface = iface_
+        self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.setObjectName("IlsLlzDockWidget")
+        self._widget = uic.loadUi(UI_PATH)
+        self.setWidget(self._widget)
+        self._wire()
+        self.refresh_layers()
+
+    def defaultArea(self):
+        return Qt.RightDockWidgetArea
+
+    def _wire(self):
+        self._widget.btnClose.clicked.connect(lambda: self.closedRequested.emit())
+        self._widget.btnCalculate.clicked.connect(lambda: self.calculateRequested.emit())
+        self._widget.btnDirection.clicked.connect(self._toggle_direction)
+
+    def _toggle_direction(self):
+        current = self._widget.btnDirection.property("direction") or "forward"
+        new = "backward" if current == "forward" else "forward"
+        self._widget.btnDirection.setProperty("direction", new)
+        self._widget.btnDirection.setText("Backward" if new == "backward" else "Forward")
+
+    def refresh_layers(self):
+        """Fill navaid (point) and routing (line) combos from layers in the canvas.
+
+        Logic follows the original script: routing layer is any layer whose
+        name contains 'routing'; navaid layer defaults to the current active
+        layer (point).
+        """
+        self._widget.cboNavaidLayer.clear()
+        self._widget.cboRoutingLayer.clear()
+        for layer in self.iface.mapCanvas().layers():
+            name = layer.name()
+            gtype = QgsWkbTypes.geometryType(layer.wkbType())
+
+            # Any line layer can be used as routing/runway
+            if gtype == QgsWkbTypes.LineGeometry:
+                self._widget.cboRoutingLayer.addItem(name, layer)
+
+            # Any point layer can be used as navaid
+            if gtype == QgsWkbTypes.PointGeometry:
+                self._widget.cboNavaidLayer.addItem(name, layer)
+
+        # Default navaid: current active layer if it is a point layer
+        al = iface.activeLayer()
+        if al:
+            gtype = QgsWkbTypes.geometryType(al.wkbType())
+            if gtype == QgsWkbTypes.PointGeometry:
+                idx = self._widget.cboNavaidLayer.findText(al.name())
+                if idx >= 0:
+                    self._widget.cboNavaidLayer.setCurrentIndex(idx)
+
+
+    def get_parameters(self):
+        navaid_layer = self._widget.cboNavaidLayer.currentData()
+        routing_layer = self._widget.cboRoutingLayer.currentData()
+        # Basic presence validation with debug logs
+        if not navaid_layer:
+            print("QBRA ILS/LLZ: no navaid layer selected")
+            return None
+        if not routing_layer:
+            print("QBRA ILS/LLZ: no routing layer selected")
+            return None
+        selection = navaid_layer.selectedFeatures()
+        if not selection:
+            print("QBRA ILS/LLZ: no navaid feature selected")
+            return None
+        feat = selection[0]
+        attrs = feat.attributes()
+
+        # Site elevation comes directly from UI numeric parameter
+        site_elev = float(self._widget.spnSiteElev.value())
+
+        # Runway remark: try to find a sensible field, else use FID
+        fields = navaid_layer.fields()
+        rwy_field_candidates = ["runway", "rwy", "thr_rwy"]
+        rwy_idx = -1
+        for name in rwy_field_candidates:
+            idx = fields.indexFromName(name)
+            if idx >= 0:
+                rwy_idx = idx
+                break
+        if rwy_idx < 0:
+            # Fallback: use feature id as runway label
+            remark = f"RWY{feat.id()}"
+        else:
+            remark = f"RWY{attrs[rwy_idx]}"
+
+        # Compute azimuth from selected routing feature (as in legacy script)
+        routing_sel = routing_layer.selectedFeatures()
+        if not routing_sel:
+            print("QBRA ILS/LLZ: no routing feature selected")
+            return None
+
+        geom = routing_sel[0].geometry()
+        if geom.isMultipart():
+            pts = geom.asMultiPolyline()[0]
+        else:
+            pts = geom.asPolyline()
+        if not pts or len(pts) < 2:
+            print("QBRA ILS/LLZ: routing geometry has insufficient vertices")
+            return None
+
+        start_point = QgsPoint(pts[0])
+        end_point = QgsPoint(pts[-1])
+        azimuth = start_point.azimuth(end_point)
+        print(f"QBRA ILS/LLZ: azimuth={azimuth}, d0={geom.length()}")
+
+        # Parameters preset for DME case (from legacy script)
+        a = 300
+        b = 20
+        h = 70
+        r = 6000 + a
+        D = 600
+        H = 20
+        L = 1500
+        phi = 40
+
+        return {
+            "active_layer": navaid_layer,
+            "azimuth": azimuth,
+            "a": a,
+            "b": b,
+            "h": h,
+            "r": r,
+            "D": D,
+            "H": H,
+            "L": L,
+            "phi": phi,
+            "remark": remark,
+            "site_elev": site_elev,
+        }

--- a/qbra_ils_llz/icons/ils_llz.svg
+++ b/qbra_ils_llz/icons/ils_llz.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <rect width="128" height="128" fill="#0b3d91"/>
+  <circle cx="64" cy="64" r="36" fill="#ffffff"/>
+  <path d="M20 96 L64 64 L108 96" stroke="#ffcc00" stroke-width="6" fill="none"/>
+  <path d="M64 28 L64 64" stroke="#ffcc00" stroke-width="6"/>
+  <text x="64" y="118" font-size="18" text-anchor="middle" fill="#ffffff">ILS/LLZ</text>
+</svg>

--- a/qbra_ils_llz/metadata.txt
+++ b/qbra_ils_llz/metadata.txt
@@ -1,0 +1,34 @@
+# This file contains metadata for your plugin.
+
+[general]
+name=QBRA ILS/LLZ
+qgisMinimumVersion=3.0
+description=QBRA Plugin for QGIS - BRA areas for ILS/LLZ single frequency
+version=0.1.0
+author=andures
+email=
+
+about=Generates BRA areas (base, left/right level, slope, walls) from a selected navaid feature, preserving legacy calculations.
+
+tracker=
+repository=
+# End of mandatory metadata
+
+# Recommended items:
+
+hasProcessingProvider=no
+changelog=Version 0.1.0
+	- Initial ILS/LLZ BRA dock UI
+	- Plugin scaffold aligned to qpansopy style
+	- Legacy calculations preserved
+
+tags=python, aviation, ILS, LLZ, BRA, surfaces
+
+homepage=
+category=Plugins
+icon=icons/ils_llz.svg
+# experimental flag
+experimental=False
+
+# deprecated flag (applies to the whole plugin, not just a single version)
+deprecated=False

--- a/qbra_ils_llz/modules/ils_llz_logic.py
+++ b/qbra_ils_llz/modules/ils_llz_logic.py
@@ -1,0 +1,259 @@
+from qgis.core import (
+    QgsVectorLayer,
+    QgsField,
+    QgsFeature,
+    QgsGeometry,
+    QgsGeometryUtils,
+    QgsProject,
+    QgsPoint,
+    QgsPointXY,
+    QgsPolygon,
+    QgsLineString,
+)
+from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtGui import QColor
+
+# Keep formulas and geometry construction identical to legacy script.
+
+def build_layers(iface, params):
+    # params expected keys: active_layer, azimuth, a, b, h, r, D, H, L, phi, remark, site_elev
+    layer = params["active_layer"]
+    selection = layer.selectedFeatures()
+    if not selection:
+        raise ValueError("Select one feature on the active layer")
+    feat = selection[0]
+    p_geom = feat.geometry().asPoint()
+
+    map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
+
+    # Helper to add Z
+    def pz(point, z):
+        cPoint = QgsPoint(point)
+        cPoint.addZValue()
+        cPoint.setZ(z)
+        return cPoint
+
+    a = params["a"]
+    b = params["b"]
+    h = params["h"]
+    r = params["r"]
+    D = params["D"]
+    H = params["H"]
+    L = params["L"]
+    phi = params["phi"]
+    azimuth = params["azimuth"]
+    remark = params["remark"]
+    site_elev = params["site_elev"]
+
+    side_elev = site_elev + H
+
+    # Points
+    pt_f = p_geom.project(a, azimuth)
+    pt_b = p_geom.project(b, azimuth - 180)
+
+    pt_al = pt_f.project(D, azimuth - 90)
+    pt_ar = pt_f.project(D, azimuth + 90)
+    pt_bl = pt_b.project(D, azimuth - 90)
+    pt_br = pt_b.project(D, azimuth + 90)
+
+    pt_Ll = pt_b.project(L, azimuth - 90)
+    pt_Lr = pt_b.project(L, azimuth + 90)
+
+    pt_rc = p_geom.project(r, azimuth)
+
+    pt_Llp = pt_Ll.project(10000, azimuth)
+    pt_alp = pt_al.project(10000, azimuth - phi)
+
+    pt_Lrp = pt_Lr.project(10000, azimuth)
+    pt_arp = pt_ar.project(10000, azimuth + phi)
+
+    pt_rl = QgsPointXY(QgsGeometryUtils.lineCircleIntersection(p_geom, r, pt_al, pt_alp, pt_rc)[1])
+    pt_rr = QgsPointXY(QgsGeometryUtils.lineCircleIntersection(p_geom, r, pt_ar, pt_arp, pt_rc)[1])
+
+    pt_drl = QgsPointXY(
+        QgsGeometryUtils.segmentIntersection(QgsPoint(pt_al), QgsPoint(pt_alp), QgsPoint(pt_Ll), QgsPoint(pt_Llp))[1]
+    )
+    pt_drr = QgsPointXY(
+        QgsGeometryUtils.segmentIntersection(QgsPoint(pt_ar), QgsPoint(pt_arp), QgsPoint(pt_Lr), QgsPoint(pt_Lrp))[1]
+    )
+
+    # Memory layer for polygons
+    z_layer = QgsVectorLayer("PolygonZ?crs=" + map_srid, f"{remark} BRA_areas", "memory")
+    fields = [
+        QgsField("id", QVariant.Int),
+        QgsField("area", QVariant.String),
+        QgsField("max_elev", QVariant.String),
+        QgsField("area_name", QVariant.String),
+        QgsField("a", QVariant.String),
+        QgsField("b", QVariant.String),
+        QgsField("h", QVariant.String),
+        QgsField("r", QVariant.String),
+        QgsField("D", QVariant.String),
+        QgsField("H", QVariant.String),
+        QgsField("L", QVariant.String),
+        QgsField("phi", QVariant.String),
+    ]
+    z_layer.dataProvider().addAttributes(fields)
+    z_layer.updateFields()
+    pr = z_layer.dataProvider()
+
+    # Base
+    base = [pz(pt_bl, site_elev), pz(pt_br, site_elev), pz(pt_ar, site_elev), pz(pt_al, site_elev), pz(pt_bl, site_elev)]
+    seg = QgsFeature()
+    seg.setGeometry(QgsPolygon(QgsLineString(base), rings=[]))
+    seg.setAttributes([
+        1,
+        "base",
+        str(site_elev),
+        remark,
+        str(round(a, 2)),
+        str(b),
+        str(h),
+        str(round(r, 2)),
+        str(D),
+        str(H),
+        str(L),
+        str(phi),
+    ])
+    pr.addFeatures([seg])
+
+    # Left level
+    llevel = [pz(pt_Ll, side_elev), pz(pt_bl, side_elev), pz(pt_al, side_elev), pz(pt_drl, side_elev), pz(pt_Ll, side_elev)]
+    seg = QgsFeature()
+    seg.setGeometry(QgsPolygon(QgsLineString(llevel), rings=[]))
+    seg.setAttributes([
+        2,
+        "left level",
+        str(side_elev),
+        remark,
+        str(round(a, 2)),
+        str(b),
+        str(h),
+        str(round(r, 2)),
+        str(D),
+        str(H),
+        str(L),
+        str(phi),
+    ])
+    pr.addFeatures([seg])
+
+    # Right level
+    rlevel = [pz(pt_br, side_elev), pz(pt_Lr, side_elev), pz(pt_drr, side_elev), pz(pt_ar, side_elev), pz(pt_br, side_elev)]
+    seg = QgsFeature()
+    seg.setGeometry(QgsPolygon(QgsLineString(rlevel), rings=[]))
+    seg.setAttributes([
+        3,
+        "right level",
+        str(side_elev),
+        remark,
+        str(round(a, 2)),
+        str(b),
+        str(h),
+        str(round(r, 2)),
+        str(D),
+        str(H),
+        str(L),
+        str(phi),
+    ])
+    pr.addFeatures([seg])
+
+    # Slope as curve + arc
+    from qgis.core import QgsCircularString
+
+    arc = QgsCircularString.fromTwoPointsAndCenter(
+        pz(pt_rl, site_elev + h),
+        pz(pt_rr, site_elev + h),
+        pz(p_geom, site_elev + h),
+    )
+
+    line_start = QgsLineString(
+        [pz(pt_rr, site_elev + h), pz(pt_ar, site_elev), pz(pt_al, site_elev), pz(pt_rl, site_elev + h)]
+    )
+    curve = line_start.toCurveType()
+    curve.addCurve(arc)
+    polygon = QgsPolygon()
+    polygon.setExteriorRing(curve)
+    geom = QgsGeometry(polygon)
+    seg = QgsFeature()
+    seg.setGeometry(geom)
+    seg.setAttributes([
+        4,
+        "slope",
+        str(site_elev + h),
+        remark,
+        str(round(a, 2)),
+        str(b),
+        str(h),
+        str(round(r, 2)),
+        str(D),
+        str(H),
+        str(L),
+        str(phi),
+    ])
+    pr.addFeatures([seg])
+
+    # Walls
+    wall1 = [pz(pt_bl, site_elev), pz(pt_bl, side_elev), pz(pt_br, side_elev), pz(pt_br, site_elev)]
+    seg = QgsFeature()
+    seg.setGeometry(QgsPolygon(QgsLineString(wall1), rings=[]))
+    seg.setAttributes([
+        5,
+        "wall",
+        str(side_elev),
+        remark,
+        str(round(a, 2)),
+        str(b),
+        str(h),
+        str(round(r, 2)),
+        str(D),
+        str(H),
+        str(L),
+        str(phi),
+    ])
+    pr.addFeatures([seg])
+
+    wall2 = [pz(pt_al, site_elev), pz(pt_al, side_elev), pz(pt_bl, side_elev), pz(pt_bl, site_elev), pz(pt_al, site_elev)]
+    seg = QgsFeature()
+    seg.setGeometry(QgsPolygon(QgsLineString(wall2), rings=[]))
+    seg.setAttributes([
+        6,
+        "wall",
+        str(side_elev),
+        remark,
+        str(round(a, 2)),
+        str(b),
+        str(h),
+        str(round(r, 2)),
+        str(D),
+        str(H),
+        str(L),
+        str(phi),
+    ])
+    pr.addFeatures([seg])
+
+    wall3 = [pz(pt_ar, site_elev), pz(pt_ar, side_elev), pz(pt_br, side_elev), pz(pt_br, site_elev), pz(pt_ar, site_elev)]
+    seg = QgsFeature()
+    seg.setGeometry(QgsPolygon(QgsLineString(wall3), rings=[]))
+    seg.setAttributes([
+        7,
+        "wall",
+        str(side_elev),
+        remark,
+        str(round(a, 2)),
+        str(b),
+        str(h),
+        str(round(r, 2)),
+        str(D),
+        str(H),
+        str(L),
+        str(phi),
+    ])
+    pr.addFeatures([seg])
+
+    # Styling
+    z_layer.renderer().symbol().setOpacity(0.5)
+    z_layer.renderer().symbol().setColor(QColor("green"))
+    z_layer.triggerRepaint()
+    z_layer.updateExtents()
+
+    return z_layer

--- a/qbra_ils_llz/qbra_plugin.py
+++ b/qbra_ils_llz/qbra_plugin.py
@@ -1,0 +1,56 @@
+from qgis.PyQt.QtCore import QObject
+from qgis.PyQt.QtWidgets import QAction
+from qgis.core import Qgis, QgsProject
+from qgis.utils import iface
+
+from .dockwidgets.ils.ils_llz_dockwidget import IlsLlzDockWidget
+from .modules.ils_llz_logic import build_layers
+
+class QbraPlugin(QObject):
+    def __init__(self, iface_):
+        super().__init__()
+        self.iface = iface_
+        self._action = None
+        self._dock = None
+
+    def initGui(self):
+        self._action = QAction("QBRA ILS/LLZ", self.iface.mainWindow())
+        self._action.setObjectName("qbra_ils_llz_action")
+        self._action.triggered.connect(self._toggle_dock)
+        self.iface.addToolBarIcon(self._action)
+        self.iface.addPluginToMenu("QBRA", self._action)
+
+    def unload(self):
+        if self._action:
+            self.iface.removePluginMenu("QBRA", self._action)
+            self.iface.removeToolBarIcon(self._action)
+            self._action = None
+        if self._dock:
+            self.iface.removeDockWidget(self._dock)
+            self._dock = None
+
+    def _toggle_dock(self):
+        if self._dock and not self._dock.isHidden():
+            self._dock.hide()
+            return
+        if not self._dock:
+            self._dock = IlsLlzDockWidget(self.iface)
+            self._dock.calculateRequested.connect(self._on_calculate)
+            self._dock.closedRequested.connect(lambda: self._dock.hide())
+            self.iface.addDockWidget(self._dock.defaultArea(), self._dock)
+        self._dock.show()
+        self._dock.raise_()
+
+    def _on_calculate(self):
+        params = self._dock.get_parameters()
+        if not params:
+            self.iface.messageBar().pushMessage("QBRA", "Invalid inputs", level=Qgis.Warning)
+            return
+        try:
+            result_layer = build_layers(self.iface, params)
+        except Exception as exc:
+            self.iface.messageBar().pushMessage("QBRA", f"Error: {exc}", level=Qgis.Critical)
+            return
+        if result_layer:
+            QgsProject.instance().addMapLayer(result_layer)
+            self.iface.messageBar().pushMessage("QBRA", "BRA areas created", level=Qgis.Success)

--- a/qbra_ils_llz/ui/ils/ils_llz_panel.ui
+++ b/qbra_ils_llz/ui/ils/ils_llz_panel.ui
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>IlsLlzPanel</class>
+ <widget class="QWidget" name="IlsLlzPanel">
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>260</width>
+    <height>140</height>
+   </size>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>4</number>
+   </property>
+   <property name="topMargin">
+    <number>4</number>
+   </property>
+   <property name="bottomMargin">
+    <number>4</number>
+   </property>
+   <property name="leftMargin">
+    <number>4</number>
+   </property>
+   <property name="rightMargin">
+    <number>4</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="lblTitle">
+     <property name="text">
+      <string>ILS/LLZ BRA</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignHCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="frameInputs">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <layout class="QFormLayout" name="formLayout">
+      <property name="horizontalSpacing">
+       <number>4</number>
+      </property>
+      <property name="verticalSpacing">
+       <number>4</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="lblNavaidLayer">
+        <property name="text">
+         <string>Navaid layer (point)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="cboNavaidLayer"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="lblRoutingLayer">
+        <property name="text">
+         <string>Routing / runway (line)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="cboRoutingLayer"/>
+      </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="lblSiteElev">
+           <property name="text">
+            <string>Site elevation (m)</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QDoubleSpinBox" name="spnSiteElev">
+           <property name="minimum">
+            <double>-1000.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>10000.000000000000000</double>
+           </property>
+           <property name="decimals">
+            <number>2</number>
+           </property>
+           <property name="value">
+            <double>0.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="btnDirection">
+     <property name="text">
+      <string>Forward</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="btnCalculate">
+     <property name="text">
+      <string>Calculate</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="btnClose">
+     <property name="text">
+      <string>Close</string>
+     </property>
+    </widget>
+   </item>
+     <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+            <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+         </property>
+        </spacer>
+     </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
## summary
This change adds a small, easy‑to‑use panel in QGIS to draw the protection areas (BRA) around an ILS/LLZ. The user only needs to pick a threshold layer, a runway layer, and type the site elevation; the plugin then creates the BRA surfaces automatically, following the behaviour of the original script but with a cleaner and more intuitive interface.
<img width="471" height="611" alt="image" src="https://github.com/user-attachments/assets/9fa35680-39ff-4820-acaf-7345d8f258a5" />
<img width="1100" height="582" alt="image" src="https://github.com/user-attachments/assets/54c15376-f96f-4a05-b46f-ae2e47abce56" />
