### PR TITLE
fix(direction): make StartEnd toggle affect azimuth and geometry (#7)

### DIFF
--- a/qbra_ils_llz/dockwidgets/ils/ils_llz_dockwidget.py
+++ b/qbra_ils_llz/dockwidgets/ils/ils_llz_dockwidget.py
@@ -29,12 +29,16 @@ class IlsLlzDockWidget(QDockWidget):
         self._widget.btnClose.clicked.connect(lambda: self.closedRequested.emit())
         self._widget.btnCalculate.clicked.connect(lambda: self.calculateRequested.emit())
         self._widget.btnDirection.clicked.connect(self._toggle_direction)
+        # Default direction: start to end
+        self._widget.btnDirection.setProperty("direction", "forward")
+        self._widget.btnDirection.setText("Direction: Start to End")
 
     def _toggle_direction(self):
         current = self._widget.btnDirection.property("direction") or "forward"
         new = "backward" if current == "forward" else "forward"
         self._widget.btnDirection.setProperty("direction", new)
-        self._widget.btnDirection.setText("Backward" if new == "backward" else "Forward")
+        label = "Direction: End to Start" if new == "backward" else "Direction: Start to End"
+        self._widget.btnDirection.setText(label)
 
     def refresh_layers(self):
         """Fill navaid (point) and routing (line) combos from layers in the canvas.
@@ -117,10 +121,13 @@ class IlsLlzDockWidget(QDockWidget):
             print("QBRA ILS/LLZ: routing geometry has insufficient vertices")
             return None
 
-        start_point = QgsPoint(pts[0])
-        end_point = QgsPoint(pts[-1])
+        # Apply direction setting to routing points
+        direction = self._widget.btnDirection.property("direction") or "forward"
+        ordered_pts = pts if direction == "forward" else list(reversed(pts))
+        start_point = QgsPoint(ordered_pts[0])
+        end_point = QgsPoint(ordered_pts[-1])
         azimuth = start_point.azimuth(end_point)
-        print(f"QBRA ILS/LLZ: azimuth={azimuth}, d0={geom.length()}")
+        print(f"QBRA ILS/LLZ: direction={direction}, azimuth={azimuth}, d0={geom.length()}")
 
         # Parameters preset for DME case (from legacy script)
         a = 300
@@ -144,5 +151,6 @@ class IlsLlzDockWidget(QDockWidget):
             "L": L,
             "phi": phi,
             "remark": remark,
+            "direction": direction,
             "site_elev": site_elev,
         }

--- a/qbra_ils_llz/modules/ils_llz_logic.py
+++ b/qbra_ils_llz/modules/ils_llz_logic.py
@@ -16,7 +16,7 @@ from qgis.PyQt.QtGui import QColor
 # Keep formulas and geometry construction identical to legacy script.
 
 def build_layers(iface, params):
-    # params expected keys: active_layer, azimuth, a, b, h, r, D, H, L, phi, remark, site_elev
+    # params expected keys: active_layer, azimuth, a, b, h, r, D, H, L, phi, remark, site_elev, direction
     layer = params["active_layer"]
     selection = layer.selectedFeatures()
     if not selection:
@@ -42,14 +42,21 @@ def build_layers(iface, params):
     L = params["L"]
     phi = params["phi"]
     azimuth = params["azimuth"]
+    direction = params.get("direction", "forward")
     remark = params["remark"]
     site_elev = params["site_elev"]
 
     side_elev = site_elev + H
 
     # Points
-    pt_f = p_geom.project(a, azimuth)
-    pt_b = p_geom.project(b, azimuth - 180)
+    # Respect direction: forward means along azimuth, backward swaps front/back construction
+    if direction == "forward":
+        pt_f = p_geom.project(a, azimuth)
+        pt_b = p_geom.project(b, azimuth - 180)
+    else:
+        # Reverse: swap sense by flipping azimuth
+        pt_f = p_geom.project(a, azimuth - 180)
+        pt_b = p_geom.project(b, azimuth)
 
     pt_al = pt_f.project(D, azimuth - 90)
     pt_ar = pt_f.project(D, azimuth + 90)


### PR DESCRIPTION
# Summary
This fix makes the “Direction: Start to End / End to Start” toggle actually change the computation. When switching to End→Start, the routing points are reversed before azimuth calculation and the geometry construction flips accordingly. Users will now see different areas/results depending on the chosen direction.
<img width="1108" height="569" alt="image" src="https://github.com/user-attachments/assets/a4f34e5e-8c78-4d2e-8838-76e3c3d6322a" />
