### PR TITLE
Use QBRA-only branding and icon (#15)

### DIFF
--- a/qBRA/icons/ils_llz.svg
+++ b/qBRA/icons/ils_llz.svg
@@ -1,5 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1e90ff"/>
+      <stop offset="100%" stop-color="#00c389"/>
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="116" height="116" rx="12" ry="12" fill="url(#g)"/>
+  <rect x="12" y="12" width="104" height="104" rx="10" ry="10" fill="#ffffff" opacity="0.9"/>
+  <text x="64" y="78" text-anchor="middle" font-family="Segoe UI, Arial, sans-serif" font-weight="700" font-size="46" fill="#1f2a44">QBRA</text>
+</svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
   <rect width="128" height="128" fill="#0b3d91"/>
   <circle cx="64" cy="64" r="36" fill="#ffffff"/>
   <path d="M20 96 L64 64 L108 96" stroke="#ffcc00" stroke-width="6" fill="none"/>


### PR DESCRIPTION
<img width="79" height="63" alt="image" src="https://github.com/user-attachments/assets/39381331-2ef5-4905-b524-a2c0dd24a349" />

# Summary
Aligns the plugin’s visible branding with the request to use “QBRA” only. Updates the toolbar/menu text, dock title, plugin name, and replaces the placeholder icon with a simple QBRA-only SVG.